### PR TITLE
vanillaEmojiPicker.js - dispatch "input" event and added closeOnSelect option

### DIFF
--- a/vanillaEmojiPicker.js
+++ b/vanillaEmojiPicker.js
@@ -7857,6 +7857,11 @@ const EmojiPicker = function(options) {
                     myField.focus()
                 }
 
+                myField.dispatchEvent(new InputEvent('input'));
+                if (this.options.closeOnSelect) {
+                    functions.closePicker.call(this, e);
+                }
+
             })
         },
 


### PR DESCRIPTION
Thanks for this! I'm locally injecting your script into voice.google.com, which doesn't have emojis in the browser version.  But selecting emojis without having already inserted text will not enable Google Voice's send button ... so I added an 'input' dispatchEvent, which triggers the send button to become enabled.  I also added a check for a "closeOnSelect" option which auto-closes the picker when an emoji is added to the insertInto target.