### PR TITLE
Fix top position of picker in vanillaEmojiPicker.js

### DIFF
--- a/vanillaEmojiPicker.js
+++ b/vanillaEmojiPicker.js
@@ -7691,7 +7691,7 @@ const EmojiPicker = function(options) {
 
             const e             = window.event;
             const clickPosX     = e.clientX;
-            const clickPosY     = e.clientY;
+            const clickPosY     = e.clientY + document.documentElement.scrollTop;
             const obj           = {};
 
             obj.left            = clickPosX;
@@ -7706,7 +7706,7 @@ const EmojiPicker = function(options) {
             picker.getBoundingClientRect().right > window.screen.availWidth ? picker.style.left = window.screen.availWidth - picker.offsetWidth + 'px' : false;
             
             if (window.innerHeight > pickerHeight) {
-                picker.getBoundingClientRect().bottom > window.innerHeight ? picker.style.top = window.innerHeight - picker.offsetHeight + 'px' : false;
+                picker.getBoundingClientRect().bottom > window.innerHeight ? picker.style.top = (window.innerHeight + document.documentElement.scrollTop) - picker.offsetHeight + 'px' : false;
             }
         },
 


### PR DESCRIPTION
In situation when users scroll webpage to down and after that they click trigger button - picker appear in not appropriate place. I mean that top position of picker does not include size of scrolling down(document.documentElement.scrollTop). I did some changes which allow to fix this problem. Please check my pull-request.