### PR TITLE
Responsive Width

### DIFF
--- a/vanillaEmojiPicker.js
+++ b/vanillaEmojiPicker.js
@@ -7521,7 +7521,7 @@ const EmojiPicker = function(options) {
                         position: fixed;
                         top: 0;
                         left: 0;
-                        width: 95vw;
+                        width: 100vw;
                         max-width: ${pickerWidth}px;
                         height: ${pickerHeight}px;
                         border-radius: 5px;

--- a/vanillaEmojiPicker.js
+++ b/vanillaEmojiPicker.js
@@ -7521,7 +7521,8 @@ const EmojiPicker = function(options) {
                         position: fixed;
                         top: 0;
                         left: 0;
-                        width: ${pickerWidth}px;
+                        width: 95vw;
+                        max-width: ${pickerWidth}px;
                         height: ${pickerHeight}px;
                         border-radius: 5px;
                         box-shadow: 0px 3px 20px 0px rgba(0, 0, 0, 0.62);

--- a/vanillaEmojiPicker.js
+++ b/vanillaEmojiPicker.js
@@ -7603,6 +7603,11 @@ const EmojiPicker = function(options) {
                         /* pointer-events: none; */
                         cursor: move;
                     }
+                    @media only screen and (max-width:400px) {
+                      #fg-emoji-picker-move {
+                        display: none;
+                      }
+                    }
 
                     .fg-picker-special-buttons a {
                         background-color: ${this.options.specialButtons ? this.options.specialButtons : '#ed5e28'};


### PR DESCRIPTION
@woody180 Originally, on mobile devices that are less than the width of the picker, the right side of the picker is hidden off screen. This PR fixes this by setting the `width` of the picker to 100vw. The original width property was changed to `max-width` so the width is the same on devices wider than mobile.

Additionally, I hid the move button on screens less than 400px since you can't really move the picker that much on mobile (if its even possible.)  I wasn't able to move it on mobile previews. I'm thinking the JS for that has to be updated.